### PR TITLE
Fix #run! always using ARGV for argument

### DIFF
--- a/src/fuse/file_system.cr
+++ b/src/fuse/file_system.cr
@@ -76,7 +76,7 @@ module Fuse
     # Runs the file system.  This will block until the file-system has been
     # unmounted.
     def run!(argv : Enumerable(String) = ARGV)
-      arguments = ARGV.map(&.to_unsafe).to_unsafe
+      arguments = argv.map(&.to_unsafe).to_unsafe
       data_ptr = self.as(Void*)
       Fuse::Binding.main(argv.size, arguments, pointerof(@operations), sizeof(Binding::Operations), data_ptr)
     end


### PR DESCRIPTION
This made `#run!` unusable when trying to pass FUSE arguments in the Crystal file.