### PR TITLE
Allow `Enumerable(Nil)` in #readdir

### DIFF
--- a/src/fuse/file_system.cr
+++ b/src/fuse/file_system.cr
@@ -129,8 +129,8 @@ module Fuse
         filler.call buf, ".".to_unsafe, Pointer(LibC::Stat).null, 0i64
         filler.call buf, "..".to_unsafe, Pointer(LibC::Stat).null, 0i64
 
-        if r.is_a?(Enumerable(String))
-          r.each { |path| filler.call buf, path.to_unsafe, Pointer(LibC::Stat).null, 0i64 }
+        if r.is_a?(Enumerable(String | Nil))
+          r.each { |path| next if path.nil?; filler.call buf, path.to_unsafe, Pointer(LibC::Stat).null, 0i64 }
         else
           r.each { |path, stat| filler.call buf, path.to_unsafe, pointerof(stat), 0i64 }
         end


### PR DESCRIPTION
Now, if you give, say, `["hello", nil]` to `#readdir`, it will just skip over `nil` rather than show you a confusing compile error.