### PR TITLE
Implement readlink

### DIFF
--- a/src/fuse/file_system.cr
+++ b/src/fuse/file_system.cr
@@ -114,9 +114,10 @@ module Fuse
         if r.nil?
           -LibC::ENOSYS
         else
-          target = r + "\0"
-          target.to_slice.copy_to buf.as(UInt8*).to_slice(size)
-          0 # the return value should be 0 for success
+          r.check_no_null_byte
+          buffer = buf.as(UInt8*).to_slice(size)
+          buffer.copy_from(r.to_unsafe, r.bytesize + 1) # + 1 to also include the terminating 0-byte
+          0                                             # the return value should be 0 for success
         end
       end
 

--- a/src/fuse/file_system.cr
+++ b/src/fuse/file_system.cr
@@ -114,10 +114,9 @@ module Fuse
         if r.nil?
           -LibC::ENOSYS
         else
-          buffer = buf.as(UInt8*).to_slice(size)
           target = r + "\0"
-          target.to_slice.copy_to(buffer)
-          0
+          target.to_slice.copy_to buf.as(UInt8*).to_slice(size)
+          0 # the return value should be 0 for success
         end
       end
 

--- a/src/fuse/file_system.cr
+++ b/src/fuse/file_system.cr
@@ -51,7 +51,7 @@ module Fuse
       nil
     end
 
-    # Reads a symlink.  Return 0 on success.
+    # Reads a symlink.  Returns a string with the target path or nil.
     def readlink(path) : String | Nil
       nil
     end


### PR DESCRIPTION
I tried to be smart for this command so that file systems using this method can forget all about zero-byte terminated strings.